### PR TITLE
Waypoint updater

### DIFF
--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -42,22 +42,17 @@ class WaypointUpdater(object):
         self.current_pose = None
         self.base_waypoints = None
 
+        self.loop()
+
+    def loop(self):
         # TODO: adjust rate
         rate = rospy.Rate(0.5)
-        start_time = 0
-
-        while not start_time:
-            start_time = rospy.Time.now().to_sec()
-
         while not rospy.is_shutdown():
             if self.current_pose is None or self.base_waypoints is None:
                 continue
 
-            elapsed = rospy.Time.now().to_sec() - start_time
             self.publish()
             rate.sleep()
-
-        rospy.spin()
 
     def publish(self):
         """publish Lane message to /final_waypoints topic"""

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -101,7 +101,7 @@ class WaypointUpdater(object):
         return math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2  + (a.z-b.z)**2)
 
     def closest_waypoint(self):
-        """ get index closest waypoint to car
+        """ get index of closest waypoint to car
 
         see https://github.com/udacity/CarND-Path-Planning-Project/blob/59a4ffc9b56f896479a7e498087ab23f6db3f100/src/main.cpp#L41-L62
 

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -3,6 +3,7 @@
 import rospy
 from geometry_msgs.msg import PoseStamped
 from styx_msgs.msg import Lane, Waypoint
+from std_msgs.msg import Int32
 
 import math
 
@@ -30,9 +31,8 @@ class WaypointUpdater(object):
 
         rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
         rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
-
-        # TODO: Add a subscriber for /traffic_waypoint and /obstacle_waypoint below
-
+        rospy.Subscriber('/traffic_waypoint', Int32, self.traffic_cb)
+        rospy.Subscriber('/obstacle_waypoint', Int32, self.obstacle_cb)
 
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
 
@@ -46,6 +46,7 @@ class WaypointUpdater(object):
 
     def waypoints_cb(self, waypoints):
         # TODO: Implement
+        print(waypoints)
         pass
 
     def traffic_cb(self, msg):

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -37,25 +37,52 @@ class WaypointUpdater(object):
         self.final_waypoints_pub = rospy.Publisher('final_waypoints', Lane, queue_size=1)
 
         # TODO: Add other member variables you need below
+        self.traffic_waypoint = -1
+        self.obstacle_waypoint = -1
+        self.current_pose = None
+        self.base_waypoints = None
+
+        # TODO: adjust rate
+        rate = rospy.Rate(0.5)
+        start_time = 0
+
+        while not start_time:
+            start_time = rospy.Time.now().to_sec()
+
+        while not rospy.is_shutdown():
+            if self.current_pose is None or self.base_waypoints is None:
+                continue
+
+            elapsed = rospy.Time.now().to_sec() - start_time
+            self.publish()
+            rate.sleep()
 
         rospy.spin()
 
+    def publish(self):
+        """publish Lane message to /final_waypoints topic"""
+
+        next_waypoint = self.next_waypoint()
+        waypoints = self.base_waypoints.waypoints
+        # shift waypoint indexes to start on next_waypoint so it's easy to grab LOOKAHEAD_WPS
+        waypoints = waypoints[next_waypoint:] + waypoints[:next_waypoint]
+        waypoints = waypoints[:LOOKAHEAD_WPS]
+
+        lane = Lane()
+        lane.waypoints = waypoints
+        self.final_waypoints_pub.publish(lane)
+
     def pose_cb(self, msg):
-        # TODO: Implement
-        pass
+        self.current_pose = msg
 
     def waypoints_cb(self, waypoints):
-        # TODO: Implement
-        print(waypoints)
-        pass
+        self.base_waypoints = waypoints
 
     def traffic_cb(self, msg):
-        # TODO: Callback for /traffic_waypoint message. Implement
-        pass
+        self.traffic_waypoint = msg
 
     def obstacle_cb(self, msg):
-        # TODO: Callback for /obstacle_waypoint message. We will implement it later
-        pass
+        self.obstacle_waypoint = msg
 
     def get_waypoint_velocity(self, waypoint):
         return waypoint.twist.twist.linear.x
@@ -65,11 +92,68 @@ class WaypointUpdater(object):
 
     def distance(self, waypoints, wp1, wp2):
         dist = 0
-        dl = lambda a, b: math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2  + (a.z-b.z)**2)
         for i in range(wp1, wp2+1):
-            dist += dl(waypoints[wp1].pose.pose.position, waypoints[i].pose.pose.position)
+            dist += self.distance_p1_p2(waypoints[wp1].pose.pose.position, waypoints[i].pose.pose.position)
             wp1 = i
         return dist
+
+    def distance_p1_p2(self, a, b):
+        return math.sqrt((a.x-b.x)**2 + (a.y-b.y)**2  + (a.z-b.z)**2)
+
+    def closest_waypoint(self):
+        """ get index closest waypoint to car
+
+        see https://github.com/udacity/CarND-Path-Planning-Project/blob/59a4ffc9b56f896479a7e498087ab23f6db3f100/src/main.cpp#L41-L62
+
+        Returns:
+            int: the index within base_waypoints
+        """
+
+        closest_len = 100000; # large number
+        closest_waypoint = 0;
+
+        for idx, waypoint in enumerate(self.base_waypoints.waypoints):
+            dist = self.distance_p1_p2(self.current_pose.pose.position, waypoint.pose.pose.position)
+            if dist < closest_len:
+                closest_len = dist
+                closest_waypoint = idx
+
+        return closest_waypoint
+
+    def next_waypoint(self):
+        """ get index of next waypoint taking direction car is facing into account
+
+        see https://github.com/udacity/CarND-Path-Planning-Project/blob/59a4ffc9b56f896479a7e498087ab23f6db3f100/src/main.cpp#L64-L87
+
+        Returns:
+            int: the index within base_waypoints
+        """
+        closest_idx = self.closest_waypoint()
+        closest = self.base_waypoints.waypoints[closest_idx]
+        num_waypoints = len(self.base_waypoints.waypoints)
+
+        x = self.current_pose.pose.position.x
+        y = self.current_pose.pose.position.y
+
+        # TODO: is this the correct value for theta?
+        rotation_to_radian = 6.28 # 1 rotation = 6.28 radians
+        theta = self.current_pose.pose.orientation.z * rotation_to_radian
+
+        map_x = closest.pose.pose.position.x
+        map_y = closest.pose.pose.position.y
+
+        heading = math.atan2((map_y - y), (map_x - x))
+        theta_pos = math.fmod(theta + (2 * math.pi), 2 * math.pi)
+        heading_pos = math.fmod(heading + (2 * math.pi), 2 * math.pi)
+        angle = math.fabs(theta_pos - heading_pos)
+
+        if angle > math.pi:
+            angle = (2 * math.pi) - angle;
+
+        if angle > math.pi / 2:
+            closest_idx = (closest_idx + 1) % num_waypoints
+
+        return closest_idx
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
From the project overview:

The /base_waypoints topic publishes a list of all waypoints for the track, so this list includes waypoints both before and after the vehicle (note that the publisher for /base_waypoints publishes only once). For this step in the project, the list published to /final_waypoints should include just a fixed number of waypoints currently ahead of the vehicle:

- The first waypoint in the list published to /final_waypoints should be the first waypoint that is currently ahead of the car.
- The total number of waypoints ahead of the vehicle that should be included in the /final_waypoints list is provided by the LOOKAHEAD_WPS variable in waypoint_updater.py.